### PR TITLE
[typo] Fix package name in installation guide

### DIFF
--- a/documentation/GettingStarted.md
+++ b/documentation/GettingStarted.md
@@ -9,7 +9,7 @@ To facilitate communication between the desktop and the Realm Database on the de
 ## Device
 Install [Realm Flipper Plugin Device](https://www.npmjs.com/package/realm-flipper-plugin-device) using NPM:
 
-`npm install realm-flipper-plugin device react-native-flipper`
+`npm install realm-flipper-plugin-device react-native-flipper`
 
 `cd ios && pod install`
 


### PR DESCRIPTION
Quick fix for a typo noticed in "getting started" guide.