### PR TITLE
Add predefined typescript types

### DIFF
--- a/realm-flipper-plugin-device/package.json
+++ b/realm-flipper-plugin-device/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.26",
   "description": "Device code for interaction with the Realm Flipper Plugin",
   "main": "dist/index.js",
+  "types: "dist/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c >> index.js"

--- a/realm-flipper-plugin-device/tsconfig.json
+++ b/realm-flipper-plugin-device/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "./dist",
     "preserveConstEnums": true,
     "target": "es5",
-    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
   },
   "exclude": ["node_modules"]
 }

--- a/realm-flipper-plugin-device/tsconfig.json
+++ b/realm-flipper-plugin-device/tsconfig.json
@@ -9,7 +9,8 @@
     "noImplicitAny": true,
     "outDir": "./dist",
     "preserveConstEnums": true,
-    "target": "es5"
+    "target": "es5",
+    "declaration": true,
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
hi,

i just add support to generate `index.d.ts` in `dist` directory & set `types` in the package.json. 
This will enable autocomplete better in typescript projects.